### PR TITLE
Allow geo.txt files to be uploaded to new task

### DIFF
--- a/app/static/app/js/components/NewTaskPanel.jsx
+++ b/app/static/app/js/components/NewTaskPanel.jsx
@@ -90,8 +90,8 @@ class NewTaskPanel extends React.Component {
         }
 
         let ext = currentFile.name.slice(-4)
-        if (ext === '.txt' && currentFile.name.indexOf('gcp_list') != 0) {
-          log(`Skipping .txt file, only gcp_list.txt permitted`)
+        if (ext === '.txt' && (currentFile.name.indexOf('gcp_list') != 0 || currentFile.name.indexOf('geo') != 0)) {
+          log(`Skipping .txt file, only gcp_list.txt and geo.txt permitted`)
           return false;
         }
 


### PR DESCRIPTION
https://github.com/AuScalableDroneCloud/Tracker/issues/177

This PR provides a temporary fix to allow `geo.txt` files to be uploaded to new tasks.

This functionality has been added by editing the Uppy upload handler. The upstream repo already possesses the desired functionality through the `dronedb` coreplugin, which should be the long-term strategy for implementing this behaviour.